### PR TITLE
Add highscore display to start screen

### DIFF
--- a/constants/UI.lua
+++ b/constants/UI.lua
@@ -1,0 +1,13 @@
+local UI = {
+    -- Spacing
+    PADDING = 10,
+    LINE_HEIGHT = 20,
+    START_Y = 10,
+    
+    -- Font sizes
+    TITLE_SIZE = 32,
+    TEXT_SIZE = 16,
+    SUBTEXT_SIZE = 12
+}
+
+return UI 

--- a/entities/UI.lua
+++ b/entities/UI.lua
@@ -1,18 +1,16 @@
 local UI = {}
-UI.__index = UI
-
 local Highscore = require('highscore')
-
--- UI Konstanten
-local UI_PADDING = 10
-local UI_LINE_HEIGHT = 20
-local UI_START_Y = 10
-local UI_TITLE_SIZE = 32
-local UI_TEXT_SIZE = 16
-local UI_SUBTEXT_SIZE = 12
+local UIConstants = require('constants.UI')
 
 function UI.new()
-    local self = setmetatable({}, UI)
+    local self = setmetatable({}, { __index = UI })
+    
+    -- Cache fonts
+    self.fonts = {
+        title = love.graphics.newFont(UIConstants.TITLE_SIZE),
+        text = love.graphics.newFont(UIConstants.TEXT_SIZE),
+        subtext = love.graphics.newFont(UIConstants.SUBTEXT_SIZE)
+    }
     
     -- Button-Konfiguration
     local buttonWidth = 200
@@ -60,18 +58,18 @@ function UI:drawStartScreen()
     love.graphics.setColor(1, 1, 1)
     
     -- Zeichne den Titel
-    love.graphics.setFont(love.graphics.newFont(UI_TITLE_SIZE))
+    love.graphics.setFont(self.fonts.title)
     love.graphics.printf("Game One", 
         0, love.graphics.getHeight()/4, 
         love.graphics.getWidth(), "center")
     
     -- Zeichne den Highscore und die Herausforderung
-    love.graphics.setFont(love.graphics.newFont(UI_TEXT_SIZE))
+    love.graphics.setFont(self.fonts.text)
     love.graphics.printf("Bisheriger Highscore: " .. Highscore.getBestScore(), 
-        0, love.graphics.getHeight()/4 + UI_LINE_HEIGHT * 2,
+        0, love.graphics.getHeight()/4 + UIConstants.LINE_HEIGHT * 2,
         love.graphics.getWidth(), "center")
     love.graphics.printf("Wirst du den Highscore knacken?", 
-        0, love.graphics.getHeight()/4 + UI_LINE_HEIGHT * 3,
+        0, love.graphics.getHeight()/4 + UIConstants.LINE_HEIGHT * 3,
         love.graphics.getWidth(), "center")
     
     -- Zeichne den Start-Button
@@ -80,11 +78,12 @@ end
 
 function UI:drawPauseScreen()
     love.graphics.setColor(1, 1, 1)
-    love.graphics.setFont(love.graphics.newFont(UI_TITLE_SIZE))
-    love.graphics.printf("Kurz durchatmen",
-        0, love.graphics.getHeight()/4,
+    love.graphics.setFont(self.fonts.title)
+    love.graphics.printf("Kurz durchatmen", 
+        0, love.graphics.getHeight()/4, 
         love.graphics.getWidth(), "center")
 
+    love.graphics.setFont(self.fonts.text)
     self:drawButton(self.backButton)
 end
 
@@ -92,22 +91,24 @@ function UI:drawGameOverScreen()
     -- Debug-Ausgaben
     local bestScore = Highscore.getBestScore()
     local previousBestScore = gameState.previousBestScore or 0
-    love.graphics.setColor(1, 1, 1)
-    love.graphics.setFont(love.graphics.newFont(UI_SUBTEXT_SIZE))
-    love.graphics.printf("Debug - Aktueller Score: " .. score, 10, 10, 300, "left")
-    love.graphics.printf("Debug - Bester Score: " .. bestScore, 10, 30, 300, "left")
-    love.graphics.printf("Debug - Vorheriger Bestwert: " .. previousBestScore, 10, 50, 300, "left")
-    love.graphics.printf("Debug - Ist neuer Highscore: " .. tostring(score > previousBestScore), 10, 70, 300, "left")
     
+    love.graphics.setColor(1, 1, 1)
+    love.graphics.setFont(self.fonts.subtext)
+    love.graphics.printf("Debug - Aktueller Score: " .. score, UIConstants.PADDING, UIConstants.START_Y, 300, "left")
+    love.graphics.printf("Debug - Bester Score: " .. bestScore, UIConstants.PADDING, UIConstants.START_Y + UIConstants.LINE_HEIGHT, 300, "left")
+    love.graphics.printf("Debug - Vorheriger Bester Score: " .. previousBestScore, UIConstants.PADDING, UIConstants.START_Y + UIConstants.LINE_HEIGHT * 2, 300, "left")
+    love.graphics.printf("Debug - Ist neuer Highscore: " .. tostring(score > previousBestScore), UIConstants.PADDING, UIConstants.START_Y + UIConstants.LINE_HEIGHT * 3, 300, "left")
+    
+    -- Game Over Text
     love.graphics.setColor(1, 0, 0)
-    love.graphics.setFont(love.graphics.newFont(UI_TITLE_SIZE))
+    love.graphics.setFont(self.fonts.title)
     love.graphics.printf("GAME OVER", 
         0, love.graphics.getHeight()/4, 
         love.graphics.getWidth(), "center")
     
     -- Zeige den aktuellen Score
     love.graphics.setColor(1, 1, 1)
-    love.graphics.setFont(love.graphics.newFont(UI_TEXT_SIZE))
+    love.graphics.setFont(self.fonts.text)
     love.graphics.printf("Dein Score: " .. score,
         0, love.graphics.getHeight()/4 + 50,
         love.graphics.getWidth(), "center")
@@ -138,7 +139,7 @@ function UI:drawGameOverScreen()
             0, love.graphics.getHeight()/4 + 150 + (i-1)*30,
             love.graphics.getWidth(), "center")
     end
-
+    
     self.startButton.text = "Neustart"
     self.startButton.y = love.graphics.getHeight() - love.graphics.getHeight() / 4
     self:drawButton(self.startButton)

--- a/entities/UI.lua
+++ b/entities/UI.lua
@@ -3,6 +3,14 @@ UI.__index = UI
 
 local Highscore = require('highscore')
 
+-- UI Konstanten
+local UI_PADDING = 10
+local UI_LINE_HEIGHT = 20
+local UI_START_Y = 10
+local UI_TITLE_SIZE = 32
+local UI_TEXT_SIZE = 16
+local UI_SUBTEXT_SIZE = 12
+
 function UI.new()
     local self = setmetatable({}, UI)
     
@@ -48,16 +56,31 @@ function UI:isPointInButton(x, y, button)
 end
 
 function UI:drawStartScreen()
+    -- Setze die Farbe auf Weiß
     love.graphics.setColor(1, 1, 1)
+    
+    -- Zeichne den Titel
+    love.graphics.setFont(love.graphics.newFont(UI_TITLE_SIZE))
     love.graphics.printf("Game One", 
         0, love.graphics.getHeight()/4, 
         love.graphics.getWidth(), "center")
     
+    -- Zeichne den Highscore und die Herausforderung
+    love.graphics.setFont(love.graphics.newFont(UI_TEXT_SIZE))
+    love.graphics.printf("Bisheriger Highscore: " .. Highscore.getBestScore(), 
+        0, love.graphics.getHeight()/4 + UI_LINE_HEIGHT * 2,
+        love.graphics.getWidth(), "center")
+    love.graphics.printf("Wirst du den Highscore knacken?", 
+        0, love.graphics.getHeight()/4 + UI_LINE_HEIGHT * 3,
+        love.graphics.getWidth(), "center")
+    
+    -- Zeichne den Start-Button
     self:drawButton(self.startButton)
 end
 
 function UI:drawPauseScreen()
     love.graphics.setColor(1, 1, 1)
+    love.graphics.setFont(love.graphics.newFont(UI_TITLE_SIZE))
     love.graphics.printf("Kurz durchatmen",
         0, love.graphics.getHeight()/4,
         love.graphics.getWidth(), "center")
@@ -70,18 +93,21 @@ function UI:drawGameOverScreen()
     local bestScore = Highscore.getBestScore()
     local previousBestScore = gameState.previousBestScore or 0
     love.graphics.setColor(1, 1, 1)
+    love.graphics.setFont(love.graphics.newFont(UI_SUBTEXT_SIZE))
     love.graphics.printf("Debug - Aktueller Score: " .. score, 10, 10, 300, "left")
     love.graphics.printf("Debug - Bester Score: " .. bestScore, 10, 30, 300, "left")
     love.graphics.printf("Debug - Vorheriger Bestwert: " .. previousBestScore, 10, 50, 300, "left")
     love.graphics.printf("Debug - Ist neuer Highscore: " .. tostring(score > previousBestScore), 10, 70, 300, "left")
     
     love.graphics.setColor(1, 0, 0)
+    love.graphics.setFont(love.graphics.newFont(UI_TITLE_SIZE))
     love.graphics.printf("GAME OVER", 
         0, love.graphics.getHeight()/4, 
         love.graphics.getWidth(), "center")
     
     -- Zeige den aktuellen Score
     love.graphics.setColor(1, 1, 1)
+    love.graphics.setFont(love.graphics.newFont(UI_TEXT_SIZE))
     love.graphics.printf("Dein Score: " .. score,
         0, love.graphics.getHeight()/4 + 50,
         love.graphics.getWidth(), "center")
@@ -109,7 +135,7 @@ function UI:drawGameOverScreen()
             love.graphics.setColor(1, 1, 1)    -- Weiße Farbe für andere Scores
         end
         love.graphics.printf(i .. ". " .. highscore,
-            0, love.graphics.getHeight()/4 + 140 + (i-1)*30,
+            0, love.graphics.getHeight()/4 + 150 + (i-1)*30,
             love.graphics.getWidth(), "center")
     end
 

--- a/main.lua
+++ b/main.lua
@@ -8,6 +8,7 @@ local Highscore = require('highscore')
 local UI_PADDING = 10
 local UI_LINE_HEIGHT = 20
 local UI_START_Y = 10
+local UI_SUBTEXT_SIZE = 12
 
 -- Cache für den Highscore
 local currentHighscore = 0
@@ -146,6 +147,9 @@ function love.draw()
     -- Setze die Farbe zurück auf Weiß für den Text
     love.graphics.setColor(1, 1, 1)
     
+    -- Setze die Schriftgröße für Debug-Texte
+    love.graphics.setFont(love.graphics.newFont(UI_SUBTEXT_SIZE))
+    
     -- Zeichne die aktuelle Position als Text (für Debugging)
     love.graphics.print('Position: ' .. math.floor(player.x), UI_PADDING, UI_START_Y)
     love.graphics.print('Geschosse: ' .. #bullets, UI_PADDING, UI_START_Y + UI_LINE_HEIGHT)
@@ -188,7 +192,7 @@ end
 -- - Highscore implementieren -> done
 -- - Highscore im Game Over Bildschirm anzeigen -> done
 -- - Highscore auf der Spielseite anzeigen -> done
--- - Highscore auf der Startseite anzeigen
+-- - Highscore auf der Startseite anzeigen -> done
 -- - Spiel beenden
 -- - Spiel speichern
 -- - Spiel laden
@@ -208,8 +212,8 @@ end
 -- - Code-Struktur verbessern
 -- - Dokumentation erstellen
 -- - Unit-Tests erstellen? (in Lua nicht üblich?)
--- - Auf GitHub hochladen
+-- - Auf GitHub hochladen -> done
 -- - Veröffentlichen auf itch.io prüfen
 -- - Release-Notes löschen
--- - Mit Branches arbeiten?
+-- - Mit Branches arbeiten -> done
 -- - README.md anpassen

--- a/main.lua
+++ b/main.lua
@@ -3,12 +3,7 @@ local Player = require('entities.Player')
 local Enemy = require('entities.Enemy')
 local UI = require('entities.UI')
 local Highscore = require('highscore')
-
--- UI Konstanten
-local UI_PADDING = 10
-local UI_LINE_HEIGHT = 20
-local UI_START_Y = 10
-local UI_SUBTEXT_SIZE = 12
+local UIConstants = require('constants.UI')
 
 -- Cache für den Highscore
 local currentHighscore = 0
@@ -148,23 +143,23 @@ function love.draw()
     love.graphics.setColor(1, 1, 1)
     
     -- Setze die Schriftgröße für Debug-Texte
-    love.graphics.setFont(love.graphics.newFont(UI_SUBTEXT_SIZE))
+    love.graphics.setFont(ui.fonts.subtext)
     
     -- Zeichne die aktuelle Position als Text (für Debugging)
-    love.graphics.print('Position: ' .. math.floor(player.x), UI_PADDING, UI_START_Y)
-    love.graphics.print('Geschosse: ' .. #bullets, UI_PADDING, UI_START_Y + UI_LINE_HEIGHT)
-    love.graphics.print('Feind Position X: ' .. math.floor(enemy.x), UI_PADDING, UI_START_Y + UI_LINE_HEIGHT * 2)
-    love.graphics.print('Feind Position Y: ' .. math.floor(enemy.y), UI_PADDING, UI_START_Y + UI_LINE_HEIGHT * 3)
-    love.graphics.print('Feind Leben: ' .. enemy.health, UI_PADDING, UI_START_Y + UI_LINE_HEIGHT * 4)
-    love.graphics.print('Punkte: ' .. score, UI_PADDING, UI_START_Y + UI_LINE_HEIGHT * 5)
-    love.graphics.print('Spieler*in Leben: ' .. player.health, UI_PADDING, UI_START_Y + UI_LINE_HEIGHT * 6)
+    love.graphics.print('Position: ' .. math.floor(player.x), UIConstants.PADDING, UIConstants.START_Y)
+    love.graphics.print('Geschosse: ' .. #bullets, UIConstants.PADDING, UIConstants.START_Y + UIConstants.LINE_HEIGHT)
+    love.graphics.print('Feind Position X: ' .. math.floor(enemy.x), UIConstants.PADDING, UIConstants.START_Y + UIConstants.LINE_HEIGHT * 2)
+    love.graphics.print('Feind Position Y: ' .. math.floor(enemy.y), UIConstants.PADDING, UIConstants.START_Y + UIConstants.LINE_HEIGHT * 3)
+    love.graphics.print('Feind Leben: ' .. enemy.health, UIConstants.PADDING, UIConstants.START_Y + UIConstants.LINE_HEIGHT * 4)
+    love.graphics.print('Punkte: ' .. score, UIConstants.PADDING, UIConstants.START_Y + UIConstants.LINE_HEIGHT * 5)
+    love.graphics.print('Spieler*in Leben: ' .. player.health, UIConstants.PADDING, UIConstants.START_Y + UIConstants.LINE_HEIGHT * 6)
     
     -- Zeige den aktuellen Highscore an
-    love.graphics.print('Bisheriger Highscore: ' .. currentHighscore, UI_PADDING, UI_START_Y + UI_LINE_HEIGHT * 7)
+    love.graphics.print('Bisheriger Highscore: ' .. currentHighscore, UIConstants.PADDING, UIConstants.START_Y + UIConstants.LINE_HEIGHT * 7)
     
     -- Zeige Unverwundbarkeitszeit an
     if player.invincible then
-        love.graphics.print('Unverwundbar: ' .. string.format("%.1f", player.invincibleTime), UI_PADDING, UI_START_Y + UI_LINE_HEIGHT * 8)
+        love.graphics.print('Unverwundbar: ' .. string.format("%.1f", player.invincibleTime), UIConstants.PADDING, UIConstants.START_Y + UIConstants.LINE_HEIGHT * 8)
     end
 end
 


### PR DESCRIPTION
## Changes
- Added highscore display to the start screen
- Added UI constants for consistent text sizes and spacing
- Improved text formatting and positioning
- Added smaller font size for debug texts
- Updated ToDo list to reflect completed features

## UI Improvements
- Added UI_TITLE_SIZE (32px) for main titles
- Added UI_TEXT_SIZE (16px) for regular text
- Added UI_SUBTEXT_SIZE (12px) for debug information
- Consistent spacing using UI_LINE_HEIGHT
- Better text alignment and positioning

## Feature Completion
The highscore is now visible on all relevant screens:
- Start screen (with motivational text)
- Game screen (during gameplay)
- Game over screen (with score comparison)

## Related ToDo
Implements the ToDo item from main.lua:
```lua
-- - Highscore auf der Startseite anzeigen
```